### PR TITLE
Add product prep to the productdetail page

### DIFF
--- a/app/controller/List.js
+++ b/app/controller/List.js
@@ -639,6 +639,7 @@ Ext.define('WhatsFresh.controller.List', {
 			for(k = 0; k <  productstore.data.all.length; k++){
 				if(productstore.data.all[k].data.name === index.data.name){
 					// Sets data for the info block on productdetail page
+					productstore.data.all[k].data.detailprep = index.data.preparation;
 					WhatsFresh.util.SetProductDetail.setProductDetailDataAndImage(k);
 				}
 			}
@@ -755,6 +756,7 @@ Ext.define('WhatsFresh.controller.List', {
 			for(k = 0; k <  productstore.data.all.length; k++){
 				if(productstore.data.all[k].data.name === index.data.name){
 					// Sets data for the info block on productdetail page
+					productstore.data.all[k].data.detailprep = index.data.preparation;
 					WhatsFresh.util.SetProductDetail.setProductDetailDataAndImage(k);
 					// productdetailView.getAt(1).items.items[0].setData(productstore.data.all[k].data);
 					var num = k;

--- a/app/view/ProductDetail.js
+++ b/app/view/ProductDetail.js
@@ -37,7 +37,7 @@ Ext.define('WhatsFresh.view.ProductDetail', {
 						xtype: 'panel',
 						id: 'ProductNameBlock',
 						itemId: 'productNameBlock',
-						tpl: '</pre><div class="list-item-title">{preparation} {name}</div>'
+						tpl: '</pre><div class="list-item-title">{detailprep} {name}</div>'
 					},
 					{	
 						xtype: 'image',


### PR DESCRIPTION
We added the product prep for display in detail view into the detailprep
on the productstore item that was set as data for the products detail
view.
