### PR TITLE
Add disclosures to list items

### DIFF
--- a/app/controller/List.js
+++ b/app/controller/List.js
@@ -534,7 +534,7 @@ Ext.define('WhatsFresh.controller.List', {
 		// THIS USES THE SAME DETAIL PAGE DATA POPULATING CODE THAT THE ON CLICK LIST ITEM EVENT DOES
 		WhatsFresh.infoClickSelf.onViewLpageListItemCommand(this, WhatsFresh.infoClickSelf, WhatsFresh.storeItem.info);
 	},
-	onViewLpageListHighlightCommand: function(record, list, index){
+	onViewLpageListHighlightCommand: function(thing, record, index, list){
 		var view = this.getListView();
 		var t = 0;
 		// THIS LOOP OPENS THE INFO PIN THAT CORESPONDS WITH THE SELETED LIST ITEM
@@ -558,6 +558,8 @@ Ext.define('WhatsFresh.controller.List', {
 	        }
 			if((view._items.items[2]._store._storeId === 'ProductList') && (WhatsFresh.infowindowFlag !== 1)){
 				// Use this for loop to find all the vendors that sell this product
+				// Highlight the list item that was selected
+				WhatsFresh.listView._items.items[2].select(WhatsFresh.ProductListStore.data.all[record]);
 				for(j = 0; j < index.data.vendors.length; j++){
 					// this if statement finds vendors who carry the specific product
 					if(WhatsFresh.marker[i].info.data.name === index.data.vendors[j]){
@@ -571,6 +573,8 @@ Ext.define('WhatsFresh.controller.List', {
 			}
 			if((view._items.items[2]._store._storeId === 'Vendor') | (WhatsFresh.infowindowFlag === 1)){
 				if(WhatsFresh.marker[i].info.data.id === index.data.id){
+					// Highlight the list item that was selected
+					WhatsFresh.listView._items.items[2].select(WhatsFresh.VendorStore.data.all[i]);
 					// This is setting the pin of the selected list item to be blue and popping open its infowindow
 					this.blueMapMarkers(t, i);
 					// add data to blue marker info window and open it
@@ -595,7 +599,7 @@ Ext.define('WhatsFresh.controller.List', {
 		t = t+1;
 		WhatsFresh.lent = t;
 	},
-	onViewLpageListItemCommand: function(record, list, index){
+	onViewLpageListItemCommand: function(thing, record, index, list){
 		var detailView = this.getDetailView();
 		var productdetailView = this.getProductdetailView();
 
@@ -610,7 +614,7 @@ Ext.define('WhatsFresh.controller.List', {
 		var productstore = Ext.data.StoreManager.lookup('Product');
 		storeInventory.removeAll();
 		var view = this.getListView();
-		this.onViewLpageListHighlightCommand(record, list, index);
+		this.onViewLpageListHighlightCommand(thing, record, index, list);
 
 		if((view._items.items[2]._store._storeId === 'Vendor') | (WhatsFresh.infowindowFlag === 1)){
 			// Store is populated with items from selected vendor

--- a/app/view/ListView.js
+++ b/app/view/ListView.js
@@ -39,6 +39,7 @@ Ext.define('WhatsFresh.view.ListView', {
 					}
 				},
 				xtype: 'list',
+				onItemDisclosure: true,
 				itemId: 'Lpagelist',
 				id: 'ListPageList',
 				loadingText: 'Loading Notes ...',
@@ -66,24 +67,30 @@ Ext.define('WhatsFresh.view.ListView', {
 				delegate: '#Lpagelist',
 				event: 'itemdoubletap',
 				fn: 'onLpagelistDisclose'
+			},
+			{
+				delegate: '#Lpagelist',
+				event: 'disclose',
+				fn: 'onLpagelistDisclose'
 			}
+			// disclose: {fn: this.onLpagelistDisclose, scope: this}
 		]
 	},
 	onBackHomeButtonTap: function(){
 		WhatsFresh.previousListItem = null;
 		this.fireEvent('viewBackHomeCommand', this);
 	},
-	onLpagelistHighlight: function(list, record, target, index, evt, options){
-		WhatsFresh.currentListItem = index.data.id;
+	onLpagelistHighlight: function(This, record, index, list){
+		WhatsFresh.currentListItem = index._record.data.id;
 		// this way if a user has previously highlighted a list item, when they tap it again, they see its details
 		if(WhatsFresh.currentListItem === WhatsFresh.previousListItem){
-			this.fireEvent('viewLpageListItemCommand', this, record, index);			
+			this.fireEvent('viewLpageListItemCommand', this, record, index._record);			
 		}else{
-			this.fireEvent('viewLpageListHighlightCommand', this, record, index);
+			this.fireEvent('viewLpageListHighlightCommand', this, record, index._record);
 			WhatsFresh.previousListItem = WhatsFresh.currentListItem;
 		}		
 	},
-	onLpagelistDisclose: function(list, record, target, index, evt, options){
-		this.fireEvent('viewLpageListItemCommand', this, record, index);
+	onLpagelistDisclose: function(This, record, index, list){
+		this.fireEvent('viewLpageListItemCommand', this, record, index._record);
 	}
 });


### PR DESCRIPTION
We added the disclosure arrow buttons to the list page list items. These
disclosures make it so that a user can click once in order to go to a
details page, instead of a double tap or a highlight and navigate tap. To
get this to work I updated some of the structure of the controller
functions so that vars passed into the functions were instantiated in a
similar maner, so that we could easily follow the transfer of data from
the view to the controller.
