### PR TITLE
Add a label for checkboxs on homepage

### DIFF
--- a/app/view/Home.js
+++ b/app/view/Home.js
@@ -86,6 +86,7 @@ Ext.define('WhatsFresh.view.Home', {
 			{
 		 	// Checkboxes for sorting data on list page
 								xtype: 'fieldset',
+								title: 'Sort by:',
 					items: [
 							{
 									xtype: 'checkboxfield',


### PR DESCRIPTION
We added a title that explains that the results are sorted by one of the
checkboxs if you choose one.
